### PR TITLE
feat: inject periodic world knowledge summary into system prompt

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -57,6 +57,7 @@ func (a *Agent) Build() string {
 		// {{USER}} is resolved as a runtime var in thread/run.go (per-session).
 		prompt = strings.ReplaceAll(prompt, "{{AGENTS}}", buildAgentsPromptSection(a.workspace))
 		prompt = strings.ReplaceAll(prompt, "{{SESSIONS_SUMMARY}}", buildSessionsSummary(a.workspace))
+		prompt = strings.ReplaceAll(prompt, "{{WORLD_KNOWLEDGE}}", buildWorldKnowledge(a.workspace))
 	}
 
 	// Auto-resolve {{DATE}} and {{CALENDAR}} from current time + agent timezone.
@@ -194,6 +195,22 @@ func buildAgentsPromptSection(workspace string) string {
 	}
 	reg := NewRegistry(workspace)
 	return reg.BuildPromptSection()
+}
+
+// buildWorldKnowledge reads system/world_knowledge.md and returns its content for prompt injection.
+func buildWorldKnowledge(workspace string) string {
+	if strings.TrimSpace(workspace) == "" {
+		return "(no world knowledge available)"
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "system", "world_knowledge.md"))
+	if err != nil {
+		return "(no world knowledge available)"
+	}
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return "(no world knowledge available)"
+	}
+	return content
 }
 
 // buildSessionsSummary reads system/sessions_summary.json and formats it for prompt injection.

--- a/cmd/templates/skills/world-knowledge-updater/SKILL.md
+++ b/cmd/templates/skills/world-knowledge-updater/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: world-knowledge-updater
+description: Periodic world knowledge updater — searches the web for recent major events beyond the model's training cutoff and writes a concise summary to the system prompt. Used by the world-knowledge cron task.
+tags: [world-knowledge, search, internal]
+---
+# World Knowledge Updater
+
+You are the world knowledge updater within the nagobot agent family. You run daily on a cron schedule. Your job is to produce a ≤1000-word summary of key world events from the past 2 months that LLMs generally do not know about, and write it to a system file for injection into the system prompt.
+
+## Freshness Check
+
+Before doing any work, check whether the knowledge file is still fresh:
+
+```
+exec: stat -c %Y {{WORKSPACE}}/system/world_knowledge.md 2>/dev/null || echo 0
+```
+
+Parse the Unix timestamp. If the file was modified **less than 3 days ago**, call `sleep_thread()` immediately and stop — no searches, no writes.
+
+If the file does not exist or was modified ≥3 days ago, proceed with the workflow below.
+
+## Workflow
+
+### 1. Plan categories
+
+Based on today's date ({{DATE}}), determine the 2-month lookback window (start date → today).
+
+Generate a categorized outline of topics to search. Recommended categories:
+
+- **Geopolitics & International Relations** — wars, treaties, sanctions, elections with global impact
+- **Economy & Finance** — central bank decisions, market crashes/surges, trade policy shifts
+- **AI & Technology** — major model releases, regulation, breakthroughs, industry shifts
+- **Science & Space** — discoveries, missions, climate milestones
+- **Health & Pandemic** — outbreaks, drug approvals, WHO decisions
+- **Energy & Environment** — energy transitions, climate agreements, natural disasters with lasting impact
+
+Only include categories where you expect significant events in the lookback window.
+
+### 2. Search by category
+
+For each category, run `web_search` with targeted queries. Use date-qualified queries (e.g., include month/year) for accuracy.
+
+Verify key claims with `web_fetch` when the search snippet is ambiguous or lacks detail.
+
+### 3. Filter and rank
+
+Apply a strict filter: **only include events that will greatly impact the next 5 years of world development.** Drop routine news, minor updates, and events that are continuations of well-known trends the model already knows.
+
+### 4. Write the summary
+
+Compose a markdown summary and write it to the system file:
+
+```
+write_file: {{WORKSPACE}}/system/world_knowledge.md
+```
+
+The file must follow this exact format:
+
+```markdown
+# World Knowledge Update
+
+> Last updated: YYYY-MM-DD | Coverage: YYYY-MM-DD to YYYY-MM-DD
+
+## Category Name
+
+- **Event title** (YYYY-MM-DD or month): 1-2 sentence factual description.
+- ...
+
+## Another Category
+
+- ...
+```
+
+Requirements:
+- Total length ≤ 1000 words (excluding the header)
+- Each bullet: event title + date + 1-2 sentence factual description
+- No opinions, speculation, or filler
+- Write in English
+- Sort events within each category by date (newest first)
+- Aim for 15-25 events total across all categories
+
+### 5. Finish
+
+After writing the file, reply with: `WORLD_KNOWLEDGE_OK`
+
+## Rules
+
+- Do NOT skip the freshness check. Unnecessary runs waste search quota.
+- Keep the summary factual and concise. No greetings, no commentary.
+- If web_search is unavailable or returns no useful results, call `sleep_thread()` and stop. Do not write a file with stale or fabricated content.

--- a/cmd/templates/system/CORE_MECHANISM.md
+++ b/cmd/templates/system/CORE_MECHANISM.md
@@ -47,6 +47,10 @@ The skills available in this system are listed below. The `use_skill` tool is th
 
 {{SKILLS}}
 
+## World Knowledge
+
+{{WORLD_KNOWLEDGE}}
+
 ## Active Sessions
 
 {{SESSIONS_SUMMARY}}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -27,6 +27,12 @@ func defaultCronSeeds() []cronpkg.Job {
 			Task:  `You must call use_skill("session-summary-dispatcher") and follow its instructions. use_skill function can not skip.`,
 			Agent: "session-summary",
 		},
+		{
+			ID:    "world-knowledge",
+			Expr:  "0 0 * * *",
+			Task:  `You must call use_skill("world-knowledge-updater") and follow its instructions. use_skill function can not skip.`,
+			Agent: "search",
+		},
 	}
 }
 


### PR DESCRIPTION
Add a daily cron job that searches the web for major world events from
the past 2 months and writes a ≤1000-word markdown summary to
system/world_knowledge.md. The skill self-checks file freshness and
skips if the last update was less than 3 days ago.

New components:
- world-knowledge-updater skill (search + write workflow)
- {{WORLD_KNOWLEDGE}} placeholder in CORE_MECHANISM.md
- buildWorldKnowledge() in agent.go for prompt injection
- world-knowledge cron seed (daily at midnight, agent: search)

Closes #95

https://claude.ai/code/session_01RmspGooRBYRrMu3FuoYsmc