### PR TITLE
tools(format): add time field to tool result frontmatter

### DIFF
--- a/tools/format.go
+++ b/tools/format.go
@@ -1,17 +1,28 @@
 package tools
 
 import (
+	"time"
+
 	"github.com/linanwx/nagobot/thread/msg"
 )
 
+// nowFn returns the current time. Indirection so tests can stub it.
+var nowFn = time.Now
+
+// nowStamp formats the current time as RFC3339 in local timezone.
+// RFC3339 is self-describing — the offset is included.
+func nowStamp() string {
+	return nowFn().Format(time.RFC3339)
+}
+
 // toolResult builds a YAML frontmatter + body tool result via msg.* helpers
 // so quoting, escaping, and multi-line value handling are correct by
-// construction. The "tool" field is always first, then "status: ok", then
-// remaining fields in sorted order. body is appended verbatim after a blank
-// line; pass body="" for header-only output.
+// construction. Leading fields are "tool", "status: ok", "time: <RFC3339>";
+// remaining fields are appended in sorted order. body is appended verbatim
+// after a blank line; pass body="" for header-only output.
 func toolResult(tool string, fields map[string]any, body string) string {
 	mapping, err := msg.SortedFieldsMapping(
-		[][2]string{{"tool", tool}, {"status", "ok"}},
+		[][2]string{{"tool", tool}, {"status", "ok"}, {"time", nowStamp()}},
 		fields,
 	)
 	if err != nil {
@@ -28,7 +39,7 @@ func toolResult(tool string, fields map[string]any, body string) string {
 // Body starts with "Error: " for backward compatibility with legacy detection.
 func toolError(tool, message string) string {
 	mapping, err := msg.SortedFieldsMapping(
-		[][2]string{{"tool", tool}, {"status", "error"}},
+		[][2]string{{"tool", tool}, {"status", "error"}, {"time", nowStamp()}},
 		nil,
 	)
 	if err != nil {

--- a/tools/format_test.go
+++ b/tools/format_test.go
@@ -3,9 +3,19 @@ package tools
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/linanwx/nagobot/thread/msg"
 )
+
+// stubNow temporarily overrides nowFn for deterministic timestamps.
+// Returns a restore function — defer it.
+func stubNow(t *testing.T, fixed time.Time) {
+	t.Helper()
+	orig := nowFn
+	nowFn = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFn = orig })
+}
 
 // ---------- toolResult ----------
 
@@ -22,6 +32,11 @@ func TestToolResult_BasicShape(t *testing.T) {
 	if got := msg.LookupScalar(mapping, "status"); got != "ok" {
 		t.Errorf("status = %q", got)
 	}
+	if got := msg.LookupScalar(mapping, "time"); got == "" {
+		t.Errorf("time field missing")
+	} else if _, err := time.Parse(time.RFC3339, got); err != nil {
+		t.Errorf("time field not RFC3339: %q (%v)", got, err)
+	}
 	if got := msg.LookupScalar(mapping, "path"); got != "/tmp/x" {
 		t.Errorf("path = %q", got)
 	}
@@ -37,11 +52,40 @@ func TestToolResult_KeyOrder(t *testing.T) {
 	out := toolResult("foo", map[string]any{"zzz": 1, "aaa": 2, "mid": 3}, "")
 	tIdx := strings.Index(out, "tool:")
 	sIdx := strings.Index(out, "status:")
+	tmIdx := strings.Index(out, "time:")
 	aIdx := strings.Index(out, "aaa:")
 	mIdx := strings.Index(out, "mid:")
 	zIdx := strings.Index(out, "zzz:")
-	if !(tIdx < sIdx && sIdx < aIdx && aIdx < mIdx && mIdx < zIdx) {
-		t.Errorf("expected order tool<status<aaa<mid<zzz, got:\n%s", out)
+	if !(tIdx < sIdx && sIdx < tmIdx && tmIdx < aIdx && aIdx < mIdx && mIdx < zIdx) {
+		t.Errorf("expected order tool<status<time<aaa<mid<zzz, got:\n%s", out)
+	}
+}
+
+func TestToolResult_TimeRoundTrips(t *testing.T) {
+	fixed := time.Date(2026, 5, 9, 12, 34, 56, 0, time.UTC)
+	stubNow(t, fixed)
+	out := toolResult("foo", nil, "")
+	mapping, _, ok := msg.ParseFrontmatter(out)
+	if !ok {
+		t.Fatalf("not parseable: %s", out)
+	}
+	got := msg.LookupScalar(mapping, "time")
+	want := fixed.Format(time.RFC3339)
+	if got != want {
+		t.Errorf("time = %q, want %q", got, want)
+	}
+}
+
+func TestToolError_HasTime(t *testing.T) {
+	fixed := time.Date(2026, 5, 9, 1, 2, 3, 0, time.UTC)
+	stubNow(t, fixed)
+	out := toolError("foo", "boom")
+	mapping, _, ok := msg.ParseFrontmatter(out)
+	if !ok {
+		t.Fatalf("not parseable: %s", out)
+	}
+	if got := msg.LookupScalar(mapping, "time"); got != fixed.Format(time.RFC3339) {
+		t.Errorf("time = %q", got)
 	}
 }
 
@@ -87,6 +131,8 @@ func TestToolResult_EmptyBody(t *testing.T) {
 
 func TestToolResult_Determinism(t *testing.T) {
 	// Map iteration order is randomized; output must be stable.
+	// Stub time so the timestamp doesn't tick mid-loop.
+	stubNow(t, time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC))
 	fields := map[string]any{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
 	first := toolResult("foo", fields, "body")
 	for i := 0; i < 30; i++ {

--- a/tools/skills.go
+++ b/tools/skills.go
@@ -97,7 +97,7 @@ func (t *UseSkillTool) run(ctx context.Context, args json.RawMessage) string {
 		prompt = strings.ReplaceAll(prompt, "{{SKILLDIR}}", dir)
 	}
 
-	header := skillHeader{Skill: a.Name}
+	header := skillHeader{Skill: a.Name, Time: nowStamp()}
 	if dir != "" {
 		header.Dir = dir
 	}
@@ -110,5 +110,6 @@ func (t *UseSkillTool) run(ctx context.Context, args json.RawMessage) string {
 
 type skillHeader struct {
 	Skill string `yaml:"skill"`
+	Time  string `yaml:"time"`
 	Dir   string `yaml:"dir,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Adds `time: <RFC3339>` to the YAML frontmatter of every tool call result so the LLM can see when each result was produced.
- Covers `toolResult`, `toolError` (used by all tools that go through the shared formatter — read_file, exec, dispatch, web_*, grep, etc.) and `use_skill`'s `skillHeader`.
- Field is placed between `status:` and the per-tool fields, keeping a stable prefix order.
- Server local timezone — RFC3339 includes the offset, so the value is self-describing.

## Sample output
```
---
tool: read_file
status: ok
time: 2026-05-09T12:27:45+01:00
path: /tmp/x
size: 1234
---

file body content
```

## Notes for reviewers
- `nowFn` is a package-level var (`var nowFn = time.Now`) so tests can stub it. `TestToolResult_Determinism` now stubs time to stay stable across iterations.
- No prompt-cache impact: tool results live in message history, are persisted with the timestamp baked in, and aren't re-formatted between requests.
- Did not touch `CmdResult`/`CmdError`/`CmdOutput` (CLI command output) — when CLI output flows back through a tool (e.g. via `exec`), the outer `toolResult` already adds `time:`.
- Wake message frontmatter still gives the user-configured timezone view at turn start; tool-result `time:` is the in-turn server stamp.

## Test plan
- [x] `go test -short ./tools/...`
- [x] `go test -short ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)