### PR TITLE
Replace inlined guide text with skill references in web tools

### DIFF
--- a/agent/section_test.go
+++ b/agent/section_test.go
@@ -237,8 +237,8 @@ func TestSectionRegistry_RealSections(t *testing.T) {
 	if err := reg.Load(); err != nil {
 		t.Fatal(err)
 	}
-	if reg.Count() < 8 {
-		t.Errorf("expected at least 8 sections, got %d", reg.Count())
+	if reg.Count() < 6 {
+		t.Errorf("expected at least 6 sections, got %d", reg.Count())
 	}
 	result := reg.Assemble()
 	if !strings.Contains(result, "How nagobot works") {

--- a/cmd/templates/skills/web-fetch-guide/SKILL.md
+++ b/cmd/templates/skills/web-fetch-guide/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: web-fetch-guide
-priority: 420
-parent: tools
+description: Use when choosing or switching web_fetch sources, or when web_fetch fails (403/503/anti-bot) — lists available fetch sources and source-selection tips.
 ---
 # web_fetch source guide
 

--- a/cmd/templates/skills/web-search-guide/SKILL.md
+++ b/cmd/templates/skills/web-search-guide/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: web-search-guide
-priority: 410
-parent: tools
+description: Use when choosing or switching web_search sources, or when web_search returns no/poor results — lists available sources, their cost and strengths, and source-selection rules.
 ---
 # web_search source guide
 

--- a/cmd/thread_runtime.go
+++ b/cmd/thread_runtime.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/linanwx/nagobot/agent"
 	"github.com/linanwx/nagobot/config"
@@ -182,24 +180,13 @@ func buildThreadManager(cfg *config.Config, enableSessions bool) (*thread.Manage
 
 	fetchHealthChecker := tools.NewFetchHealthChecker(fetchProviders)
 
-	webSearchGuide := ""
-	if guideData, err := os.ReadFile(filepath.Join(workspace, "system", "WEB_SEARCH_GUIDE.md")); err == nil {
-		webSearchGuide = strings.TrimSpace(string(guideData))
-	}
-	webFetchGuide := ""
-	if guideData, err := os.ReadFile(filepath.Join(workspace, "system", "WEB_FETCH_GUIDE.md")); err == nil {
-		webFetchGuide = strings.TrimSpace(string(guideData))
-	}
-
 	toolRegistry.RegisterDefaultTools(workspace, tools.DefaultToolsConfig{
 		ExecTimeout:         cfg.GetExecTimeout(),
 		WebSearchMaxResults: cfg.GetWebSearchMaxResults(),
-		WebSearchGuide:      webSearchGuide,
 		SearchProviders:     searchProviders,
 		SearchHealthChecker: searchHealthChecker,
 		FetchProviders:      fetchProviders,
 		FetchHealthChecker:  fetchHealthChecker,
-		WebFetchGuide:       webFetchGuide,
 		RestrictToWorkspace: cfg.GetExecRestrictToWorkspace(),
 		Skills:              skillRegistry,
 		LogsDir:             logsDir,
@@ -268,8 +255,8 @@ func buildThreadManager(cfg *config.Config, enableSessions bool) (*thread.Manage
 		SkillsDir:           skillsDir,
 		BuiltinSkillsDir:    builtinSkillsDir,
 		SessionsDir:         sessionsDir,
-		ContextWindowTokens:  cfg.GetContextWindowTokens(),
-		MaxCompletionTokens:  cfg.Thread.MaxTokens,
+		ContextWindowTokens: cfg.GetContextWindowTokens(),
+		MaxCompletionTokens: cfg.Thread.MaxTokens,
 		Sessions:            sessions,
 		HealthChannelsFn:    healthChannelsFn,
 		ProviderFactory:     providerFactory,
@@ -281,9 +268,9 @@ func buildThreadManager(cfg *config.Config, enableSessions bool) (*thread.Manage
 			}
 			return c.Thread.Models
 		},
-		SessionTimezoneFor:  cfg.SessionTimezone,
-		MetricsStore:        metricsStore,
-		Sections:            initSectionRegistry(workspace),
+		SessionTimezoneFor: cfg.SessionTimezone,
+		MetricsStore:       metricsStore,
+		Sections:           initSectionRegistry(workspace),
 	}), searchHealthChecker, fetchHealthChecker, nil
 }
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -212,12 +212,10 @@ type Registry struct {
 type DefaultToolsConfig struct {
 	ExecTimeout         int
 	WebSearchMaxResults int
-	WebSearchGuide      string // content from WEB_SEARCH_GUIDE.md
 	SearchProviders     map[string]SearchProvider
 	SearchHealthChecker *SearchHealthChecker
 	FetchProviders      map[string]FetchProvider
 	FetchHealthChecker  *SearchHealthChecker // reused type — tracks fetch outcomes
-	WebFetchGuide       string              // content from WEB_FETCH_GUIDE.md
 	RestrictToWorkspace bool
 	Skills              SkillProvider
 	LogsDir             string // Log files directory for health diagnostics
@@ -333,8 +331,8 @@ func (r *Registry) RegisterDefaultTools(workspace string, cfg DefaultToolsConfig
 	r.Register(&EditFileTool{workspace: workspace})
 	r.Register(NewExecTool(workspace, cfg.ExecTimeout, cfg.RestrictToWorkspace))
 	r.Register(&HealthTool{Workspace: workspace, LogsDir: cfg.LogsDir})
-	r.Register(&WebSearchTool{defaultMaxResults: cfg.WebSearchMaxResults, providers: cfg.SearchProviders, healthChecker: cfg.SearchHealthChecker, Guide: cfg.WebSearchGuide})
-	r.Register(&WebFetchTool{providers: cfg.FetchProviders, healthChecker: cfg.FetchHealthChecker, Guide: cfg.WebFetchGuide})
+	r.Register(&WebSearchTool{defaultMaxResults: cfg.WebSearchMaxResults, providers: cfg.SearchProviders, healthChecker: cfg.SearchHealthChecker})
+	r.Register(&WebFetchTool{providers: cfg.FetchProviders, healthChecker: cfg.FetchHealthChecker})
 	if cfg.Skills != nil {
 		r.Register(NewUseSkillTool(cfg.Skills))
 	}

--- a/tools/web_tools.go
+++ b/tools/web_tools.go
@@ -26,8 +26,12 @@ type WebSearchTool struct {
 	defaultMaxResults int
 	providers         map[string]SearchProvider
 	healthChecker     *SearchHealthChecker
-	Guide             string // injected from WEB_SEARCH_GUIDE.md, appended to error responses
 }
+
+// webSearchGuideSkill is the skill that holds the full source-selection guide.
+// Error/empty responses reference it via use_skill instead of inlining the guide
+// text, so repeated failures don't bloat the conversation history.
+const webSearchGuideSkill = "web-search-guide"
 
 // Def returns the tool definition.
 func (t *WebSearchTool) Def() provider.ToolDef {
@@ -128,11 +132,11 @@ func (t *WebSearchTool) Run(ctx context.Context, args json.RawMessage) string {
 }
 
 func (t *WebSearchTool) sourceError(msg string) string {
-	return buildSourceError(msg, t.healthChecker, t.Guide)
+	return buildSourceError(msg, t.healthChecker, webSearchGuideSkill)
 }
 
 func (t *WebSearchTool) searchError(source, query string, err error) string {
-	return buildToolError("web_search", fmt.Sprintf("Error: search on %q failed: %v", source, err), t.healthChecker, t.Guide)
+	return buildToolError("web_search", fmt.Sprintf("Error: search on %q failed: %v", source, err), t.healthChecker, webSearchGuideSkill)
 }
 
 func (t *WebSearchTool) emptyResults(source, query string) string {
@@ -146,7 +150,7 @@ func (t *WebSearchTool) emptyResults(source, query string) string {
 	if t.healthChecker != nil {
 		body.WriteString(t.healthChecker.DetailedStatus())
 	}
-	appendGuide(&body, t.Guide)
+	appendGuideSkillHint(&body, webSearchGuideSkill)
 	return toolResult("web_search", fields, body.String())
 }
 
@@ -167,8 +171,11 @@ const webFetchCacheTTL = 10 * time.Minute
 type WebFetchTool struct {
 	providers     map[string]FetchProvider
 	healthChecker *SearchHealthChecker // reused from web_search — tracks fetch outcomes
-	Guide         string              // injected from WEB_FETCH_GUIDE.md, appended to error responses
 }
+
+// webFetchGuideSkill is the skill that holds the full fetch source guide.
+// Error responses reference it via use_skill instead of inlining the guide text.
+const webFetchGuideSkill = "web-fetch-guide"
 
 // Def returns the tool definition.
 func (t *WebFetchTool) Def() provider.ToolDef {
@@ -312,11 +319,11 @@ func (t *WebFetchTool) Run(ctx context.Context, args json.RawMessage) string {
 }
 
 func (t *WebFetchTool) fetchSourceError(msg string) string {
-	return buildSourceError(msg, t.healthChecker, t.Guide)
+	return buildSourceError(msg, t.healthChecker, webFetchGuideSkill)
 }
 
 func (t *WebFetchTool) fetchError(source, fetchURL string, err error) string {
-	return buildToolError("web_fetch", fmt.Sprintf("Error: fetch %q via %s failed: %v", fetchURL, source, err), t.healthChecker, t.Guide)
+	return buildToolError("web_fetch", fmt.Sprintf("Error: fetch %q via %s failed: %v", fetchURL, source, err), t.healthChecker, webFetchGuideSkill)
 }
 
 func webFetchCacheLookup(key string) (string, bool) {
@@ -378,32 +385,34 @@ func extractTextContent(html string) string {
 }
 
 // buildSourceError builds an error message with health status and guide for source selection failures.
-func buildSourceError(msg string, hc *SearchHealthChecker, guide string) string {
+func buildSourceError(msg string, hc *SearchHealthChecker, guideSkill string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("Error: %s.\n\n", msg))
 	if hc != nil {
 		sb.WriteString(hc.DetailedStatus())
 	}
-	appendGuide(&sb, guide)
+	appendGuideSkillHint(&sb, guideSkill)
 	return sb.String()
 }
 
-// buildToolError builds a tool error with health status and guide.
-func buildToolError(toolName, errMsg string, hc *SearchHealthChecker, guide string) string {
+// buildToolError builds a tool error with health status and a guide skill hint.
+func buildToolError(toolName, errMsg string, hc *SearchHealthChecker, guideSkill string) string {
 	var sb strings.Builder
 	sb.WriteString(errMsg)
 	sb.WriteString("\n\nTry a different source.\n")
 	if hc != nil {
 		sb.WriteString(hc.DetailedStatus())
 	}
-	appendGuide(&sb, guide)
+	appendGuideSkillHint(&sb, guideSkill)
 	return toolError(toolName, sb.String())
 }
 
-func appendGuide(sb *strings.Builder, guide string) {
-	if guide != "" {
-		sb.WriteString("\n")
-		sb.WriteString(guide)
-		sb.WriteString("\n")
+// appendGuideSkillHint appends a one-line pointer to the source-selection guide
+// skill instead of inlining the full guide text. This keeps error/empty results
+// compact so repeated failures don't accumulate large duplicated guides in the
+// conversation history.
+func appendGuideSkillHint(sb *strings.Builder, guideSkill string) {
+	if guideSkill != "" {
+		sb.WriteString(fmt.Sprintf("\nFor source options and selection guidance, call use_skill(%q).\n", guideSkill))
 	}
 }


### PR DESCRIPTION
## Summary

Refactor web search and fetch tools to reference guide content via `use_skill()` hints instead of inlining full guide text in error and empty-result responses. This prevents repeated failures from bloating conversation history with duplicated guide content.

## Key Changes

- **Removed guide field injection**: Deleted `Guide` fields from `WebSearchTool` and `WebFetchTool` structs and removed guide file reading logic from `cmd/thread_runtime.go`
- **Introduced guide skill constants**: Added `webSearchGuideSkill` and `webFetchGuideSkill` constants that reference the skill names (`"web-search-guide"` and `"web-fetch-guide"`)
- **Updated error/empty-result handling**: Modified `buildSourceError()`, `buildToolError()`, and `emptyResults()` to call `appendGuideSkillHint()` instead of `appendGuide()`
- **New hint function**: Replaced `appendGuide()` with `appendGuideSkillHint()` that outputs a one-line pointer (`For source options and selection guidance, call use_skill("web-search-guide").`) instead of inlining the full guide text
- **Updated skill metadata**: Converted `web-search-guide` and `web-fetch-guide` from tool-parent skills with priority ordering to standalone skills with descriptive metadata
- **Removed config plumbing**: Deleted `WebSearchGuide` and `WebFetchGuide` fields from `DefaultToolsConfig` struct
- **Test adjustment**: Updated section count expectation in `TestSectionRegistry_RealSections` from 8 to 6 (reflecting removal of guide skills from the parent:tools hierarchy)

## Implementation Details

The guide skills are now referenced by constant name rather than injected content, making error responses compact and reusable. When web_search or web_fetch fails or returns empty results, the tool instructs the LLM to call `use_skill()` to access the full guide, keeping the conversation history lean while preserving access to detailed source-selection guidance.

https://claude.ai/code/session_0191y2nrSbEVzgSKtuEtktZx