### PR TITLE
refactor(auth): remove Anthropic OAuth login, keep API-key provider

### DIFF
--- a/cmd/oauth.go
+++ b/cmd/oauth.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -13,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"os/exec"
 	"runtime"
 	"sort"
@@ -58,11 +56,6 @@ var authProviders = map[string]*oauthConfig{
 	"openai-oauth": openaiOAuthConfig,
 }
 
-// pasteTokenProviders lists providers that use paste-token auth (no PKCE).
-var pasteTokenProviders = map[string]bool{
-	"anthropic-oauth": true,
-}
-
 var authCmd = &cobra.Command{
 	Use:     "auth",
 	Aliases: []string{"oauth"},
@@ -96,19 +89,10 @@ var authOpenAICmd = &cobra.Command{
 	},
 }
 
-var authAnthropicCmd = &cobra.Command{
-	Use:   "anthropic",
-	Short: "Login with Anthropic/Claude account via setup-token",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return runPasteTokenLogin("anthropic-oauth")
-	},
-}
-
 func init() {
 	authCmd.AddCommand(authStatusCmd)
 	authCmd.AddCommand(authLogoutCmd)
 	authCmd.AddCommand(authOpenAICmd)
-	authCmd.AddCommand(authAnthropicCmd)
 	rootCmd.AddCommand(authCmd)
 
 	// Wire OAuth token refresh into the provider factory.
@@ -246,53 +230,10 @@ func runOAuthLogin(providerName string) error {
 	return nil
 }
 
-// runPasteTokenLogin handles paste-token authentication for providers like Anthropic.
-// The user runs `claude setup-token` separately, then pastes the resulting token here.
-func runPasteTokenLogin(providerName string) error {
-	if !pasteTokenProviders[providerName] {
-		return fmt.Errorf("unsupported paste-token provider: %s", providerName)
-	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	fmt.Println("To get a setup-token, run in a separate terminal:")
-	fmt.Println()
-	fmt.Println("  claude setup-token")
-	fmt.Println()
-
-	fmt.Print("Paste your setup-token (sk-ant-oat01-...): ")
-	scanner := bufio.NewScanner(os.Stdin)
-	if !scanner.Scan() {
-		return fmt.Errorf("failed to read token: %w", scanner.Err())
-	}
-	token := strings.TrimSpace(scanner.Text())
-
-	if !strings.HasPrefix(token, "sk-ant-oat") {
-		return fmt.Errorf("invalid token: must start with sk-ant-oat")
-	}
-
-	cfg.SetOAuthToken(providerName, &config.OAuthTokenConfig{
-		AccessToken: token,
-		TokenType:   "bearer",
-	})
-	if err := cfg.Save(); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
-	}
-
-	fmt.Printf("\nSuccessfully authenticated with %s!\n", providerName)
-	return nil
-}
-
-// allAuthProviderNames returns a sorted list of all provider names that support any form of OAuth/token auth.
+// allAuthProviderNames returns a sorted list of all provider names that support OAuth login.
 func allAuthProviderNames() []string {
-	names := make([]string, 0, len(authProviders)+len(pasteTokenProviders))
+	names := make([]string, 0, len(authProviders))
 	for name := range authProviders {
-		names = append(names, name)
-	}
-	for name := range pasteTokenProviders {
 		names = append(names, name)
 	}
 	sort.Strings(names)
@@ -344,9 +285,7 @@ func runAuthStatus(_ *cobra.Command, _ []string) error {
 
 func runAuthLogout(_ *cobra.Command, args []string) error {
 	providerName := strings.TrimSpace(args[0])
-	_, inOAuth := authProviders[providerName]
-	_, inPaste := pasteTokenProviders[providerName]
-	if !inOAuth && !inPaste {
+	if _, ok := authProviders[providerName]; !ok {
 		return fmt.Errorf("unsupported provider: %s (supported: %s)", providerName, strings.Join(allAuthProviderNames(), ", "))
 	}
 

--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -40,7 +40,6 @@ var providerURLs = map[string]string{
 	"deepseek":           "https://platform.deepseek.com",
 	"openrouter":         "https://openrouter.ai/keys",
 	"anthropic":          "https://console.anthropic.com",
-	"anthropic-oauth":    "https://claude.com",
 	"moonshot-cn":        "https://platform.moonshot.cn",
 	"moonshot-global":    "https://platform.moonshot.ai",
 	"zhipu-cn":           "https://open.bigmodel.cn",
@@ -765,19 +764,13 @@ func authenticateProvider(existing *config.Config, providerName string) error {
 		return nil // Already authenticated.
 	}
 
-	_, supportsOAuth := authProviders[providerName]
-	supportsPasteToken := pasteTokenProviders[providerName]
-	if supportsOAuth || supportsPasteToken {
-		oauthLabel := "Login with OAuth (use your existing account)"
-		if supportsPasteToken {
-			oauthLabel = "Paste setup-token (run 'claude setup-token' first)"
-		}
+	if _, supportsOAuth := authProviders[providerName]; supportsOAuth {
 		authChoice := "oauth"
 		err := huh.NewForm(huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("How to authenticate with "+providerName+"?").
 				Options(
-					huh.NewOption(oauthLabel, "oauth"),
+					huh.NewOption("Login with OAuth (use your existing account)", "oauth"),
 					huh.NewOption("Enter API key manually", "apikey"),
 				).
 				Value(&authChoice),
@@ -786,9 +779,6 @@ func authenticateProvider(existing *config.Config, providerName string) error {
 			return err
 		}
 		if authChoice == "oauth" {
-			if supportsPasteToken {
-				return runPasteTokenLogin(providerName)
-			}
 			return runOAuthLogin(providerName)
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -186,7 +186,6 @@ type ProvidersConfig struct {
 	OpenAI            *ProviderConfig   `json:"openai,omitempty" yaml:"openai,omitempty"`
 	OpenAIOAuth       *OAuthTokenConfig `json:"openaiOAuth,omitempty" yaml:"openaiOAuth,omitempty"`
 	WhatAI            *ProviderConfig   `json:"whatai,omitempty" yaml:"whatai,omitempty"` // api.whatai.cc relay; OpenAI-shape chat, DALL-E-3-style image protocol
-	AnthropicOAuth    *OAuthTokenConfig `json:"anthropicOAuth,omitempty" yaml:"anthropicOAuth,omitempty"`
 	Gemini            *ProviderConfig   `json:"gemini,omitempty" yaml:"gemini,omitempty"`
 	XAI               *ProviderConfig   `json:"xai,omitempty" yaml:"xai,omitempty"`
 	MiMo              *ProviderConfig   `json:"mimo,omitempty" yaml:"mimo,omitempty"`

--- a/config/provider.go
+++ b/config/provider.go
@@ -224,8 +224,6 @@ func (c *Config) GetOAuthToken(providerName string) *OAuthTokenConfig {
 	switch providerName {
 	case "openai", "openai-oauth":
 		return c.Providers.OpenAIOAuth
-	case "anthropic", "anthropic-oauth":
-		return c.Providers.AnthropicOAuth
 	}
 	return nil
 }
@@ -235,8 +233,6 @@ func (c *Config) SetOAuthToken(providerName string, token *OAuthTokenConfig) {
 	switch providerName {
 	case "openai", "openai-oauth":
 		c.Providers.OpenAIOAuth = token
-	case "anthropic", "anthropic-oauth":
-		c.Providers.AnthropicOAuth = token
 	}
 }
 
@@ -254,7 +250,7 @@ func (c *Config) EnsureProviderConfigFor(providerName string) *ProviderConfig {
 		return pc
 	}
 	// Provider not found or field is nil — allocate and set it.
-	// OAuth-only providers (e.g. "anthropic-oauth") have no ProviderConfig.
+	// OAuth-only providers (e.g. "openai-oauth") have no ProviderConfig.
 	pc := &ProviderConfig{}
 	switch providerName {
 	case "openai", "openai-oauth":

--- a/provider/anthropic.go
+++ b/provider/anthropic.go
@@ -95,10 +95,6 @@ func init() {
 	apiKeyReg.EnvKey = "ANTHROPIC_API_KEY"
 	apiKeyReg.EnvBase = "ANTHROPIC_API_BASE"
 	RegisterProvider("anthropic", apiKeyReg)
-
-	// "anthropic-oauth" — OAuth token auth (no env var, no API base override).
-	oauthReg := shared
-	RegisterProvider("anthropic-oauth", oauthReg)
 }
 
 // AnthropicProvider implements the Provider interface for Anthropic.
@@ -148,11 +144,6 @@ func anthropicThinkingBudget(maxTokens int) (int64, bool) {
 	return int64(budget), true
 }
 
-// isAnthropicOAuthToken returns true if the key is an Anthropic OAuth token.
-func isAnthropicOAuthToken(key string) bool {
-	return strings.HasPrefix(key, "sk-ant-oat")
-}
-
 // newAnthropicProvider creates a new Anthropic provider.
 func newAnthropicProvider(apiKey, apiBase, modelType, modelName string, maxTokens int, temperature float64) *AnthropicProvider {
 	if modelName == "" {
@@ -166,18 +157,7 @@ func newAnthropicProvider(apiKey, apiBase, modelType, modelName string, maxToken
 		aoption.WithMaxRetries(sdkMaxRetries),
 		aoption.WithMiddleware(anthropicRateLimitMiddleware),
 	}
-	if isAnthropicOAuthToken(apiKey) {
-		// OAuth token: use Bearer auth + required beta/identity headers.
-		// Must match Claude Code's request signature for Anthropic to accept.
-		opts = append(opts,
-			aoption.WithAuthToken(apiKey),
-			aoption.WithHeader("anthropic-beta", "claude-code-20250219,oauth-2025-04-20"),
-			aoption.WithHeader("user-agent", "claude-cli/2.1.92"),
-			aoption.WithHeader("x-app", "cli"),
-		)
-	} else {
-		opts = append(opts, aoption.WithAPIKey(apiKey))
-	}
+	opts = append(opts, aoption.WithAPIKey(apiKey))
 
 	client := anthropic.NewClient(opts...)
 
@@ -530,19 +510,7 @@ func (p *AnthropicProvider) Chat(ctx context.Context, req *Request) (ChatResult,
 		Messages:  messages,
 		Tools:     tools,
 	}
-	if isAnthropicOAuthToken(p.apiKey) {
-		// OAuth requires Claude Code identity in the system prompt.
-		blocks := []anthropic.TextBlockParam{{
-			Text: "You are Claude Code, Anthropic's official CLI for Claude.",
-		}}
-		if systemPrompt != "" {
-			blocks = append(blocks, anthropic.TextBlockParam{
-				Text:         systemPrompt,
-				CacheControl: anthropic.NewCacheControlEphemeralParam(),
-			})
-		}
-		params.System = blocks
-	} else if systemPrompt != "" {
+	if systemPrompt != "" {
 		params.System = []anthropic.TextBlockParam{{
 			Text:         systemPrompt,
 			CacheControl: anthropic.NewCacheControlEphemeralParam(),
@@ -574,11 +542,7 @@ func (p *AnthropicProvider) Chat(ctx context.Context, req *Request) (ChatResult,
 		)
 	}
 
-	providerLabel := "anthropic"
-	if isAnthropicOAuthToken(p.apiKey) {
-		providerLabel = "anthropic-oauth"
-	}
-	resp := &Response{ProviderLabel: providerLabel, ModelLabel: p.modelName}
+	resp := &Response{ProviderLabel: "anthropic", ModelLabel: p.modelName}
 	adapter := newStreamAdapter(ctx, resp)
 
 	go func() {

--- a/provider/factory.go
+++ b/provider/factory.go
@@ -165,7 +165,7 @@ func providerAPIKey(cfg *config.Config, providerName string) string {
 	}
 
 	// OAuth-only providers — only OAuth token, no env var / static key fallback.
-	if providerName == "openai-oauth" || providerName == "anthropic-oauth" {
+	if providerName == "openai-oauth" {
 		return oauthAccessToken(cfg, providerName)
 	}
 


### PR DESCRIPTION
Remove Anthropic OAuth login path entirely while keeping:
- Anthropic API-key provider
- OpenRouter Claude models
- OpenAI OAuth login

Anthropic blocked OAuth-token access, so `anthropic-oauth` is dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4z2CNcogaD9ovCqKpBdXA